### PR TITLE
set topics support URL

### DIFF
--- a/src/components/topic/homepage/TopicsHomepage.js
+++ b/src/components/topic/homepage/TopicsHomepage.js
@@ -82,7 +82,7 @@ const TopicsHomepage = (props) => {
       <Masthead
         nameMsg={messages.topicsToolName}
         descriptionMsg={messages.topicsToolDescription}
-        link="https://mediacloud.org/tools/"
+        link={process.env.SUPPORT_URL}
       />
       {content}
     </div>


### PR DESCRIPTION
This PR sets topics support URL, to URL defined in `process.env.SUPPORT_URL`