### PR TITLE
fix: Incorrect years shown on collected stories chart

### DIFF
--- a/src/components/vis/AttentionOverTimeChart.js
+++ b/src/components/vis/AttentionOverTimeChart.js
@@ -50,18 +50,6 @@ function yAxisTitleByInterval(interval) {
 
 function makePercentage(value) { return value * 100; }
 
-export function dataAsSeries(data, fieldName = 'count') {
-  // clean up the data
-  const dates = data.map(d => d.date);
-  // Get all the time intervals between the dates we have in our data
-  const timeIntervalsMs = dates.slice(1).map((date, index) => date - dates[index]);
-  // Use average of the interval as the regular interval we want to use, this can give a good estimate the no. of stories per day
-  const intervalMs = timeIntervalsMs.reduce((acc, interval) => acc + interval, 0) / timeIntervalsMs.length;
-  const intervalDays = intervalMs / SECS_PER_DAY;
-  const values = data.map(d => d[fieldName] / intervalDays);
-  return { data: values, pointInterval: intervalMs, pointStart: dates[0] };
-}
-
 /**
  * Fill gaps between days.
  */
@@ -87,6 +75,17 @@ export function fillDayGaps(data) {
     mostRecent = d;
   });
   return filledData;
+}
+
+export function dataAsSeries(data, fieldName = 'count') {
+  // clean up the data
+  const filledData = fillDayGaps(data);
+  const dates = filledData.map(d => d.date);
+  // turning variable time unit into days
+  const intervalMs = (dates[1] - dates[0]);
+  const intervalDays = intervalMs / SECS_PER_DAY;
+  const values = filledData.map(d => d[fieldName] / intervalDays);
+  return { data: values, pointInterval: intervalMs, pointStart: dates[0] };
 }
 
 

--- a/src/components/vis/AttentionOverTimeChart.js
+++ b/src/components/vis/AttentionOverTimeChart.js
@@ -53,8 +53,10 @@ function makePercentage(value) { return value * 100; }
 export function dataAsSeries(data, fieldName = 'count') {
   // clean up the data
   const dates = data.map(d => d.date);
-  // turning variable time unit into days
-  const intervalMs = (dates[1] - dates[0]);
+  // Get all the time intervals between the dates we have in our data
+  const timeIntervalsMs = dates.slice(1).map((date, index) => date - dates[index]);
+  // Use average of the interval as the regular interval we want to use, this can give a good estimate the no. of stories per day
+  const intervalMs = timeIntervalsMs.reduce((acc, interval) => acc + interval, 0) / timeIntervalsMs.length;
   const intervalDays = intervalMs / SECS_PER_DAY;
   const values = data.map(d => d[fieldName] / intervalDays);
   return { data: values, pointInterval: intervalMs, pointStart: dates[0] };
@@ -257,6 +259,7 @@ class AttentionOverTimeChart extends React.Component {
         } else {
           values = Object.values(groupedData).map(d => (d.sum !== undefined ? d.sum : d.count));
         }
+
         return {
           ...thisSeries,
           data: values,


### PR DESCRIPTION
This PR fixes an issue on the collected stories chart in which data points stretch far into the future.  Upon investigation it was observed that the Collected Stories Chart makes the assumption that data is collected at regular time intervals to render dates on the x-axis. Thus whenever data points are at irregular intervals, this approach leads to inaccuracies in how the dates are displayed. 

To resolve this we have used the `fillDayGaps` method in the `AttentionOverTimeChart` to ensure that data is at regular intervals by filling dates with missing data with zeroes.

Fixes #22 

In the current PR the Collected stories would look as follows 
![Screenshot 2024-10-24 at 16 05 41](https://github.com/user-attachments/assets/db1bba71-5474-4c2c-85f5-0465a2bd3e45)

as opposed to :
![Screenshot 2024-10-24 at 16 06 46](https://github.com/user-attachments/assets/c6736d8e-f806-4fdd-8415-0508c4466436)

