### PR TITLE
Improve Payload CMS data fetching implementation

### DIFF
--- a/server/views/cms/documents.py
+++ b/server/views/cms/documents.py
@@ -49,19 +49,16 @@ def fetch_cms_content(url, application_name=None, params=None):
         return response.json(), response.status_code
 
     except requests.RequestException as e:
-        error_message = {'message': f'Request failed: {str(e)}'}
-        logger.error(error_message)
-        return jsonify(error_message), 500
+        logger.error(f'Request failed: {str(e)}')
+        return jsonify({'message': 'An internal error has occurred.'}), 500
     
     except ValueError as e:
-        error_message = {'message': f'Invalid JSON response: {str(e)}'}
-        logger.error(error_message)
-        return jsonify(error_message), 500
+        logger.error(f'Invalid JSON response: {str(e)}')
+        return jsonify({'message': 'An internal error has occurred.'}), 500
     
     except Exception as e:
-        error_message = {'message': f'Unexpected error: {str(e)}'}
-        logger.error(error_message)
-        return jsonify(error_message), 500
+        logger.error(f'Unexpected error: {str(e)}')
+        return jsonify({'message': 'An internal error has occurred.'}), 500
 
 
 @app.route('/api/cms/pages', methods=['GET'])

--- a/server/views/cms/documents.py
+++ b/server/views/cms/documents.py
@@ -33,10 +33,9 @@ BASE_URL = BASE_URL.rstrip('/')
 
 def fetch_cms_content(url, application_name=None, params=None):
     """Helper function to make API requests with consistent headers"""
-    headers = {
-        'Authorization': f'users API-Key {API_KEY}',
-        'Content-Type': 'application/json'
-    }
+    headers = dict(request.headers)
+    headers.pop('Host', None)
+    headers['Authorization'] = f'users API-Key {API_KEY}'
     if application_name:
        headers['Cs-App'] = application_name
     try:

--- a/server/views/cms/documents.py
+++ b/server/views/cms/documents.py
@@ -31,81 +31,70 @@ if missing_configs:
 BASE_URL = BASE_URL.rstrip('/')
 
 
-def handle_api_request(func):
-    """Helper to handle common API request patterns and error handling"""
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        try:
-            response = func(*args, **kwargs)
-            response.raise_for_status()
-            return response.json(), response.status_code
-            
-        except requests.RequestException as e:
-            error_message = {'message': f'Request failed: {str(e)}'}
-            logger.error(error_message)
-            return jsonify(error_message), 500
-            
-        except ValueError as e:
-            error_message = {'message': f'Invalid JSON response: {str(e)}'}
-            logger.error(error_message)
-            return jsonify(error_message), 500
-            
-        except Exception as e:
-            error_message = {'message': f'Unexpected error: {str(e)}'}
-            logger.error(error_message)
-            return jsonify(error_message), 500
-    
-    return wrapper
-
-def make_api_request(url, application_name=None, params=None):
+def fetch_cms_content(url, application_name=None, params=None):
     """Helper function to make API requests with consistent headers"""
-    headers = {
-        'Authorization': f'users API-Key {API_KEY}',
-        'Content-Type': 'application/json'
-    }
+    try:
+        headers = {
+            'Authorization': f'users API-Key {API_KEY}',
+            'Content-Type': 'application/json'
+        }
+        
+        if application_name:
+            headers['Cs-App'] = application_name
     
-    if application_name:
-        headers['Cs-App'] = application_name
- 
-    escaped_args = {k: html.escape(v) for k, v in (params or {}).items()}
-    return requests.get(url, params=escaped_args, headers=headers)
+        escaped_args = {k: html.escape(v) for k, v in (params or {}).items()}
+
+        response = requests.get(url, params=escaped_args, headers=headers)
+        response.raise_for_status()
+        return response.json(), response.status_code
+
+    except requests.RequestException as e:
+        error_message = {'message': f'Request failed: {str(e)}'}
+        logger.error(error_message)
+        return jsonify(error_message), 500
+    
+    except ValueError as e:
+        error_message = {'message': f'Invalid JSON response: {str(e)}'}
+        logger.error(error_message)
+        return jsonify(error_message), 500
+    
+    except Exception as e:
+        error_message = {'message': f'Unexpected error: {str(e)}'}
+        logger.error(error_message)
+        return jsonify(error_message), 500
 
 
 @app.route('/api/cms/pages', methods=['GET'])
 @api_error_handler
 @arguments_required('cs-app')
-@handle_api_request
 def api_fetch_page_content():
     application_name = html.escape(request.args.get('cs-app'))
     url = f"{BASE_URL}/{application_name}-pages"
-    return make_api_request(url, application_name, request.args)
+    return fetch_cms_content(url, application_name, request.args)
   
 
 @app.route('/api/cms/collections', methods=['GET'])
 @api_error_handler
 @arguments_required('collection')
-@handle_api_request
 def api_fetch_collections():
     collection = html.escape(request.args.get('collection'))
     url = f'{BASE_URL}/{collection}'
-    return make_api_request(url, params=request.args)
+    return fetch_cms_content(url, params=request.args)
 
 
 @app.route('/api/cms/globals', methods=['GET'])
 @api_error_handler
 @arguments_required('cs-app')
-@handle_api_request
 def api_fetch_globals():
     application_name = html.escape(request.args.get('cs-app'))
     url = f'{BASE_URL}/globals/settings-{application_name}-site'
-    return make_api_request(url, application_name, request.args)
+    return fetch_cms_content(url, application_name, request.args)
 
 
 @app.route('/api/cms/forms', methods=['GET'])
 @api_error_handler
 @arguments_required('form')
-@handle_api_request
 def api_fetch_forms():
     form = html.escape(request.args.get('form'))
     url = f'{BASE_URL}/globals/{form}-form'
-    return make_api_request(url, params=request.args)
+    return fetch_cms_content(url, params=request.args)

--- a/server/views/cms/documents.py
+++ b/server/views/cms/documents.py
@@ -8,6 +8,7 @@ from flask import jsonify, request
 import requests
 import html
 
+from functools import wraps
 from server import app
 from server.util.request import api_error_handler, arguments_required
 
@@ -29,78 +30,82 @@ if missing_configs:
 
 BASE_URL = BASE_URL.rstrip('/')
 
+
+def handle_api_request(func):
+    """Helper to handle common API request patterns and error handling"""
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            response = func(*args, **kwargs)
+            response.raise_for_status()
+            return response.json(), response.status_code
+            
+        except requests.RequestException as e:
+            error_message = {'message': f'Request failed: {str(e)}'}
+            logger.error(error_message)
+            return jsonify(error_message), 500
+            
+        except ValueError as e:
+            error_message = {'message': f'Invalid JSON response: {str(e)}'}
+            logger.error(error_message)
+            return jsonify(error_message), 500
+            
+        except Exception as e:
+            error_message = {'message': f'Unexpected error: {str(e)}'}
+            logger.error(error_message)
+            return jsonify(error_message), 500
+    
+    return wrapper
+
+def make_api_request(url, application_name=None, params=None):
+    """Helper function to make API requests with consistent headers"""
+    headers = {
+        'Authorization': f'users API-Key {API_KEY}',
+        'Content-Type': 'application/json'
+    }
+    
+    if application_name:
+        headers['Cs-App'] = application_name
+ 
+    escaped_args = {k: html.escape(v) for k, v in (params or {}).items()}
+    return requests.get(url, params=escaped_args, headers=headers)
+
+
 @app.route('/api/cms/pages', methods=['GET'])
 @api_error_handler
 @arguments_required('cs-app')
+@handle_api_request
 def api_fetch_page_content():
     application_name = html.escape(request.args.get('cs-app'))
     url = f"{BASE_URL}/{application_name}-pages"
-    headers = dict(request.headers)
-    headers['Authorization'] = f'users API-Key {API_KEY}'
-    headers['Cs-App'] = application_name
-    try:
-        escaped_args = {k: html.escape(v) for k, v in request.args.items()}
-        response = requests.get(url, escaped_args, headers=headers)
-        return response.json(), response.status_code
-    except:
-        error_message = {'message': 'Received an invalid or malformed response'}
-        logger.error(error_message)
-        return jsonify(error_message), 500
-
+    return make_api_request(url, application_name, request.args)
+  
 
 @app.route('/api/cms/collections', methods=['GET'])
 @api_error_handler
 @arguments_required('collection')
+@handle_api_request
 def api_fetch_collections():
     collection = html.escape(request.args.get('collection'))
     url = f'{BASE_URL}/{collection}'
-    headers = dict(request.headers)
-    headers['Authorization'] = f'users API-Key {API_KEY}'
-
-    try:
-        escaped_args = {k: html.escape(v) for k, v in request.args.items()}
-        response = requests.get(url, escaped_args, headers=headers)
-        return response.json(), response.status_code
-    except:
-        error_message = {'message': 'Received an invalid or malformed response'}
-        logger.error(error_message)
-        return jsonify(error_message), 500
+    return make_api_request(url, params=request.args)
 
 
 @app.route('/api/cms/globals', methods=['GET'])
 @api_error_handler
 @arguments_required('cs-app')
+@handle_api_request
 def api_fetch_globals():
     application_name = html.escape(request.args.get('cs-app'))
     url = f'{BASE_URL}/globals/settings-{application_name}-site'
-    headers = dict(request.headers)
-    headers['Authorization'] = f'users API-Key {API_KEY}'
-    
-    try:
-        escaped_args = {k: html.escape(v) for k, v in request.args.items()}
-        response = requests.get(url, escaped_args, headers=headers)
-        return response.json(), response.status_code
-    except:
-        error_message = {'message': 'Received an invalid or malformed response'}
-        logger.error(error_message)
-        return jsonify(error_message), 500
+    return make_api_request(url, application_name, request.args)
 
 
 @app.route('/api/cms/forms', methods=['GET'])
 @api_error_handler
 @arguments_required('form')
+@handle_api_request
 def api_fetch_forms():
-    form =  html.escape(request.args.get('form'))
- 
+    form = html.escape(request.args.get('form'))
     url = f'{BASE_URL}/globals/{form}-form'
-    headers = dict(request.headers)
-    headers['Authorization'] = f'users API-Key {API_KEY}'
-    
-    try:
-        escaped_args = {k: html.escape(v) for k, v in request.args.items()}
-        response = requests.get(url, escaped_args, headers=headers)
-        return response.json(), response.status_code
-    except:
-        error_message = {'message': 'Received an invalid or malformed response'}
-        logger.error(error_message)
-        return jsonify(error_message), 500
+    return make_api_request(url, params=request.args)

--- a/server/views/cms/documents.py
+++ b/server/views/cms/documents.py
@@ -33,32 +33,23 @@ BASE_URL = BASE_URL.rstrip('/')
 
 def fetch_cms_content(url, application_name=None, params=None):
     """Helper function to make API requests with consistent headers"""
+    headers = {
+        'Authorization': f'users API-Key {API_KEY}',
+        'Content-Type': 'application/json'
+    }
+    if application_name:
+       headers['Cs-App'] = application_name
     try:
-        headers = {
-            'Authorization': f'users API-Key {API_KEY}',
-            'Content-Type': 'application/json'
-        }
-        
-        if application_name:
-            headers['Cs-App'] = application_name
-    
         escaped_args = {k: html.escape(v) for k, v in (params or {}).items()}
-
         response = requests.get(url, params=escaped_args, headers=headers)
-        response.raise_for_status()
         return response.json(), response.status_code
-
-    except requests.RequestException as e:
-        logger.error(f'Request failed: {str(e)}')
-        return jsonify({'message': 'An internal error has occurred.'}), 500
-    
-    except ValueError as e:
-        logger.error(f'Invalid JSON response: {str(e)}')
-        return jsonify({'message': 'An internal error has occurred.'}), 500
-    
-    except Exception as e:
-        logger.error(f'Unexpected error: {str(e)}')
-        return jsonify({'message': 'An internal error has occurred.'}), 500
+    except requests.RequestException:
+        logger.exception('Request failed')
+    except ValueError:
+        logger.exception('Invalid JSON response')    
+    except Exception:
+        logger.exception('Unexpected error')
+    return jsonify({'message': 'An internal error has occurred.'}), 500
 
 
 @app.route('/api/cms/pages', methods=['GET'])


### PR DESCRIPTION
This pull request addresses an issue encountered when accessing content from the Payload CMS API deployed in production.

It was observed that requests with forwarded HTTP headers from the web application were being redirected to a 404 page, which pointed to the `charter.africa` site. This appears to be an unrelated issue that requires further investigation. 
However, discarding (not forwarding) the HTTP request headers from the client (React Application) when making a request to Payload CMS via the Flask backend resolves this issue.

Minor improvements have been implemented by introducing a unified function to handle all Payload CMS API requests and error handling. Furthermore, the existing Flask view functions have been refactored to make use of this function.