### PR TITLE
Fix/Deploy issues on web tools

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,1 @@
-https://github.com/heroku/heroku-buildpack-python.git
-
+https://github.com/CodeForAfrica/heroku-buildpack-python.git

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -18,6 +18,8 @@ greenlet==0.4.15
 deco==0.5.2
 Flask-Executor==0.9.3
 newspaper3k==0.2.8
+lxml==5.3.0
+lxml_html_clean==0.2.1
 gevent==20.5.0
 Jinja2==3.0.3
 itsdangerous==2.0.1


### PR DESCRIPTION
This PR addresses two issues identified during the deployment of the web tools using Dokku:
1. Build failing due to [unsupported Python version](https://devcenter.heroku.com/changelog-items/3094) specified in [runtime.txt](https://github.com/CodeForAfrica/web-tools/blob/main/runtime.txt)
   This has been fixed by [forking](https://github.com/CodeForAfrica/heroku-buildpack-python) the Python buildpack repo and checking out to a commit that supports `Python 3.8.x.`

2. `explorer` silently failing to start due to unmet dependencies.
    It was observed that we're using `newspaper3k` `v0.2.8`, which depends on `lxml`. The pip installation seems to install a version that does not include `lxml.html.clean`. A hint for this error is provided below:
```
  File "/app/.heroku/python/lib/python3.8/site-packages/newspaper/parsers.py", line 12, in <module>
    import lxml.html.clean
  File "/app/.heroku/python/lib/python3.8/site-packages/lxml/html/clean.py", line 18, in <module>
    raise ImportError(
ImportError: lxml.html.clean module is now a separate project lxml_html_clean.
Install lxml[html_clean] or lxml_html_clean directly.
```

The error is not logged on Dokku or within the container because of how we start the application using [Gunicorn](https://github.com/CodeForAfrica/web-tools/blob/main/Procfile). The only way to view this error is by manually starting a container from the image built by Dokku and running the application with Python, using the full path to the Python executable in `/app/.heroku/python/bin/`

This has been fixed by pinning `lxml` to `5.3.0` and  `lxml_html_clean` to `0.2.1` in the `requirements/common.txt. These versions were tested locally and work without any issues.