### PR TITLE
Fix misc UI issues on sources

### DIFF
--- a/src/components/common/header/SourcesAppMenu.js
+++ b/src/components/common/header/SourcesAppMenu.js
@@ -22,7 +22,7 @@ const localMessages = {
   suggestSource: { id: 'sources.menu.items.suggestSource', defaultMessage: 'Suggest a Source' },
   pendingSuggestions: { id: 'sources.menu.items.pendingSuggestions', defaultMessage: 'Pending Suggestions' },
   geographicCollections: { id: 'sources.menu.items.geographicCollections', defaultMessage: 'Browse Geographic Collections' },
-  otherCollections: { id: 'sources.menu.items.otherCollections', defaultMessage: 'Browse Other Collections' },
+  collections: { id: 'sources.menu.items.collections', defaultMessage: 'Browse Collections' },
 };
 
 const SourcesAppMenu = (props) => {
@@ -33,11 +33,8 @@ const SourcesAppMenu = (props) => {
         <MenuItem onClick={() => { props.handleItemClick('home', true); }}>
           <FormattedMessage {...messages.home} />
         </MenuItem>
-        <MenuItem onClick={() => { props.handleItemClick('collections/country-and-state', true); }}>
-          <FormattedMessage {...localMessages.geographicCollections} />
-        </MenuItem>
         <MenuItem onClick={() => { props.handleItemClick('collections/media-cloud', true); }}>
-          <FormattedMessage {...localMessages.otherCollections} />
+          <FormattedMessage {...localMessages.collections} />
         </MenuItem>
         <MenuItem onClick={() => { props.handleItemClick('search', true); }}>
           <FormattedMessage {...localMessages.search} />
@@ -71,7 +68,7 @@ const SourcesAppMenu = (props) => {
           <FormattedMessage {...localMessages.geographicCollections} />
         </MenuItem>
         <MenuItem onClick={() => { props.handleItemClick('collections/media-cloud', true); }}>
-          <FormattedMessage {...localMessages.otherCollections} />
+          <FormattedMessage {...localMessages.collections} />
         </MenuItem>
         <MenuItem onClick={() => { props.handleItemClick('search', true); }}>
           <FormattedMessage {...messages.search} />

--- a/src/components/common/header/SubMenu.js
+++ b/src/components/common/header/SubMenu.js
@@ -8,7 +8,7 @@ import AppButton from '../AppButton';
 import SourcesAppMenu from './SourcesAppMenu';
 import { defaultMenuOriginProps } from '../../util/uiUtil';
 import messages from '../../../resources/messages';
-import { urlToMediaData } from '../../../lib/urlUtil';
+import { urlToMediaData, urlToResearch } from '../../../lib/urlUtil';
 
 
 class SubMenu extends React.Component {
@@ -63,6 +63,14 @@ class SubMenu extends React.Component {
                 target="new"
                 href={urlToMediaData('media')}
                 label={formatMessage(messages.mediaDataToolName)}
+              />
+            </li>
+            <li>
+              <AppButton
+                variant="text"
+                target="new"
+                href={urlToResearch()}
+                label={formatMessage(messages.researchToolName)}
               />
             </li>
           </ul>

--- a/src/components/common/statbar/Stat.js
+++ b/src/components/common/statbar/Stat.js
@@ -31,9 +31,11 @@ class Stat extends React.Component {
       );
     }
     return (
-      <DataCard className="stat">
-        {contentToShow}
-      </DataCard>
+      data !== '?' && (
+        <DataCard className="stat">
+          {contentToShow}
+        </DataCard>
+      )
     );
   }
 }

--- a/src/components/common/statbar/Stat.js
+++ b/src/components/common/statbar/Stat.js
@@ -24,18 +24,21 @@ class Stat extends React.Component {
       contentToShow = content;
     } else {
       contentToShow = (
-        <Box textAlign="center">
+        <Box textAlign="center" height={50}>
           <small><FormattedMessage {...message} /> { helpDisplayContent }</small>
           <em>{data || 'n/a'}</em>
         </Box>
       );
     }
+
+    if (!(data !== '?')) {
+      return null;
+    }
+
     return (
-      data !== '?' && (
-        <DataCard className="stat">
-          {contentToShow}
-        </DataCard>
-      )
+      <DataCard className="stat">
+        {contentToShow}
+      </DataCard>
     );
   }
 }

--- a/src/components/source/collection/CollectionDetailsContainer.js
+++ b/src/components/source/collection/CollectionDetailsContainer.js
@@ -48,7 +48,6 @@ class CollectionDetailsContainer extends React.Component {
             </Col>
             <Col lg={6} xs={12}>
               <CollectionSourceRepresentation collection={collection} />
-              <CollectionMetadataCoverageSummaryContainer collection={collection} />
               <CollectionSimilarContainer collectionId={collection.tags_id} filename={filename} />
             </Col>
           </Row>

--- a/src/components/source/collection/CollectionDetailsContainer.js
+++ b/src/components/source/collection/CollectionDetailsContainer.js
@@ -9,7 +9,6 @@ import CollectionTopWordsContainer from './CollectionTopWordsContainer';
 import CollectionGeographyContainer from './CollectionGeographyContainer';
 import CollectionSourceRepresentation from './CollectionSourceRepresentation';
 import CollectionSimilarContainer from './CollectionSimilarContainer';
-import CollectionMetadataCoverageSummaryContainer from './CollectionMetadataCoverageSummaryContainer';
 import { hasPermissions, getUserRoles, PERMISSION_MEDIA_EDIT } from '../../../lib/auth';
 import { WarningNotice } from '../../common/Notice';
 import TabSelector from '../../common/TabSelector';

--- a/src/components/source/mediaSource/SourceDetailsContainer.js
+++ b/src/components/source/mediaSource/SourceDetailsContainer.js
@@ -93,9 +93,6 @@ class SourceDetailsContainer extends React.Component {
             <SourceStatInfo sourceId={source.media_id} />
             <Row>
               <Col lg={6} md={6} sm={12}>
-                <SourceMetadataStatBar source={source} columnWidth={6} />
-              </Col>
-              <Col lg={6} md={6} sm={12}>
                 <CollectionList
                   title={formatMessage(localMessages.sourceDetailsCollectionsTitle)}
                   intro={formatMessage(localMessages.sourceDetailsCollectionsIntro, {
@@ -104,6 +101,9 @@ class SourceDetailsContainer extends React.Component {
                   collections={source.media_source_tags}
                   collectionSets={collectionSets}
                 />
+              </Col>
+              <Col lg={6} md={6} sm={12}>
+                <SourceMetadataStatBar source={source} columnWidth={6} />
               </Col>
             </Row>
           </span>

--- a/src/components/source/mediaSource/SourceStatInfo.js
+++ b/src/components/source/mediaSource/SourceStatInfo.js
@@ -26,7 +26,7 @@ const SourceStatInfo = (props) => {
   }
   let formattedDateStr;
   if (sourceInfo.start_date) {
-    const startDate = healthStartDateToMoment(sourceInfo.start_date);
+    const startDate = healthStartDateToMoment(sourceInfo.start_date, false);
     formattedDateStr = formatDate(startDate, { month: 'numeric', year: 'numeric' });
   } else {
     formattedDateStr = formatMessage(messages.unknown);

--- a/src/components/source/mediaSource/SourceStatInfo.js
+++ b/src/components/source/mediaSource/SourceStatInfo.js
@@ -26,7 +26,7 @@ const SourceStatInfo = (props) => {
   }
   let formattedDateStr;
   if (sourceInfo.start_date) {
-    const startDate = healthStartDateToMoment(sourceInfo.start_date, false);
+    const startDate = healthStartDateToMoment(sourceInfo.start_date);
     formattedDateStr = formatDate(startDate, { month: 'numeric', year: 'numeric' });
   } else {
     formattedDateStr = formatMessage(messages.unknown);

--- a/src/lib/dateUtil.js
+++ b/src/lib/dateUtil.js
@@ -119,7 +119,7 @@ export function jobStatusDateToMoment(statusDate, strict = true) {
 }
 
 export function healthStartDateToMoment(healthStartDate, strict = true) {
-  return moment(healthStartDate.substring(0, DB_DATE_FORMAT.length), DB_DATE_FORMAT, strict);
+  return moment(healthStartDate.substring(0, SHORT_SOLR_DATE_FORMAT.length), SHORT_SOLR_DATE_FORMAT, strict);
 }
 
 export function sourceSuggestionDateToMoment(suggestionDate, strict = true) {

--- a/src/lib/urlUtil.js
+++ b/src/lib/urlUtil.js
@@ -51,6 +51,10 @@ export function urlToMediaData(param) {
   return `https://civicsignal.africa/#/${param}`;
 }
 
+export function urlToResearch() {
+  return 'https://research.civicsignal.africa/';
+}
+
 export function urlToExplorerQuery(name, keywords, sourceIds, collectionIds, startDate, endDate) {
   let sources = sourceIds || [];
   let collections = collectionIds || [];

--- a/src/resources/messages.js
+++ b/src/resources/messages.js
@@ -16,6 +16,7 @@ const messages = {
   explorerToolDescription: { id: 'app.explorer.description', defaultMessage: 'Get a quick overview of how your topic of interest is covered by digital news media by exploring attention, language, and entities.' },
   mediaDataToolName: { id: 'app.mediadata.name', defaultMessage: 'Media Data' },
   mediaDataToolDescription: { id: 'app.mediadata.description', defaultMessage: 'MediaData is Code for Africa’s research department, producing data and analyses of the African media ecosystem.' },
+  researchToolName: { id: 'app.research.name', defaultMessage: 'Research' },
   learnMoreButton: { id: 'app.learn.button', defaultMessage: 'Learn More' },
   launchButton: { id: 'app.launch.button', defaultMessage: 'Launch' },
   readGuide: { id: 'app.readGuide', defaultMessage: 'Visit Our Support Page' },


### PR DESCRIPTION
This PR includes several changes to improve the user interface of the `sources` application. The following changes have been implemented:

### 1. Updates to `SourcesAppMenu` component:
Remove `Browse Geographic Collections` menu item (which renders a page with not content) and rename the `Browse Other Collections` to `Browse Collections`

**Before:**
![Screenshot 2025-02-11 at 13 37 49](https://github.com/user-attachments/assets/7218ff6a-5f63-4f00-823d-f08ca41c7e8c)

**After:**
![Screenshot 2025-02-11 at 13 38 03](https://github.com/user-attachments/assets/09ece54f-cdc4-4f40-abca-b679191dda78)


### 2. Remove CollectionMetadataCoverageSummaryContainer:
Remove `CollectionMetadataCoverageSummaryContainer` which does not display any meaningful information.

**Before**
![Screenshot 2025-02-11 at 13 47 22](https://github.com/user-attachments/assets/ce799389-58c7-408c-addf-52ca73ac975f)

**After**
![Screenshot 2025-02-11 at 13 48 55](https://github.com/user-attachments/assets/2ca69a48-b514-4d72-953e-329733dec6fa)


### 3. Fix Issues on Data Card Component :
Fix the issue of an invalid date string displaying on the 'Covered Since' card when viewing details about a source. Additionally, ensure that cards are only rendered when there is actual data, preventing unnecessary cards from being shown with no meaningful information.
**Before**
![Screenshot 2025-02-11 at 13 55 46](https://github.com/user-attachments/assets/a8d94756-dca6-4a2d-b17e-8cb7d5824acc)

**After**
![Screenshot 2025-02-11 at 13 50 40](https://github.com/user-attachments/assets/3edf8e9f-0819-4aab-a3fd-775cd9a6c8fd)

Fixes #37 