### PR TITLE
Fix issues in the main application navbar menu

### DIFF
--- a/src/components/common/header/Masthead.js
+++ b/src/components/common/header/Masthead.js
@@ -15,7 +15,7 @@ const Masthead = props => (
         </Col>
         <Col lg={2} />
         <Col lg={3}>
-          <a className="user-guide" href={props.link}><FormattedMessage {...messages.readGuide} /></a>
+          <a className="user-guide" href={props.link} target="_blank" rel="noreferrer"><FormattedMessage {...messages.readGuide} /></a>
         </Col>
       </Row>
     </Grid>

--- a/src/components/common/header/NavToolbar.js
+++ b/src/components/common/header/NavToolbar.js
@@ -64,7 +64,7 @@ const NavToolbar = (props) => {
                 <AppButton
                   variant="text"
                   href={SUPPORT_URL}
-                  target="new"
+                  target="_blank"
                   label={formatMessage(localMessages.support)}
                 />
               </li>

--- a/src/components/common/header/SourcesAppMenu.js
+++ b/src/components/common/header/SourcesAppMenu.js
@@ -64,9 +64,6 @@ const SourcesAppMenu = (props) => {
         <MenuItem onClick={() => { props.handleItemClick('home', true); }}>
           <FormattedMessage {...messages.home} />
         </MenuItem>
-        <MenuItem onClick={() => { props.handleItemClick('collections/country-and-state', true); }}>
-          <FormattedMessage {...localMessages.geographicCollections} />
-        </MenuItem>
         <MenuItem onClick={() => { props.handleItemClick('collections/media-cloud', true); }}>
           <FormattedMessage {...localMessages.collections} />
         </MenuItem>


### PR DESCRIPTION
This PR applies minor fixes to the Civic Signal web tools navigation bar menu, including:
- Ensuring the support link (an external link) opens in a new tab.
- Removing the Browse Geographic Collections menu item for non-admin users (this was previously removed for only admin users in #41 )