### PR TITLE
Fix/Activate account page

### DIFF
--- a/src/components/common/story/SelectedStoryContainer.js
+++ b/src/components/common/story/SelectedStoryContainer.js
@@ -109,12 +109,10 @@ class SelectedStoryContainer extends React.Component {
                     </ListItemText>
                   </MenuItem>
                   <MenuItem
-                    onClick={() =>
-                      window.open(
+                    onClick={() => window.open(
                         `/api/stories/${selectedStoryId}/raw.html`,
                         '_blank'
-                      )
-                    }
+                      )}
                   >
                     <ListItemText>
                       <FormattedMessage {...localMessages.viewCachedHtml} />
@@ -226,11 +224,9 @@ class SelectedStoryContainer extends React.Component {
                 <Col lg={6}>
                   <TagListContainer
                     story={selectedStory}
-                    tagToShow={(t) =>
-                      t.tag_sets_id !== nytThemesSet &&
-                      t.tag_sets_id !== cliffOrgsSet &&
-                      t.tag_sets_id !== cliffPeopleSet
-                    }
+                    tagToShow={(t) => t.tag_sets_id !== nytThemesSet
+                      && t.tag_sets_id !== cliffOrgsSet
+                      && t.tag_sets_id !== cliffPeopleSet}
                   />
                 </Col>
               </Row>
@@ -296,8 +292,7 @@ const mapDispatchToProps = (dispatch) => ({
   },
 });
 
-const fetchAsyncData = (dispatch, { id, isAdmin }) =>
-  dispatch(fetchStory(id, { text: isAdmin }));
+const fetchAsyncData = (dispatch, { id, isAdmin }) => dispatch(fetchStory(id, { text: isAdmin }));
 
 export default injectIntl(
   connect(

--- a/src/components/common/story/StoryQuoteTable.js
+++ b/src/components/common/story/StoryQuoteTable.js
@@ -75,8 +75,7 @@ const mapStateToProps = (state) => ({
   quotes: state.story.quotes.all,
 });
 
-const fetchAsyncData = (dispatch, { storyId }) =>
-  dispatch(fetchStoryQuotes(storyId));
+const fetchAsyncData = (dispatch, { storyId }) => dispatch(fetchStoryQuotes(storyId));
 
 export default injectIntl(
   connect(mapStateToProps)(

--- a/src/components/user/Activated.js
+++ b/src/components/user/Activated.js
@@ -8,9 +8,9 @@ import { ErrorNotice } from '../common/Notice';
 
 const localMessages = {
   workedTitle: { id: 'user.activated.worked.title', defaultMessage: 'Your Account is Activated' },
-  workedIntro: { id: 'user.activated.worked.intro', defaultMessage: 'Your Media Cloud account is now active!' },
+  workedIntro: { id: 'user.activated.worked.intro', defaultMessage: 'Your CivicSignal account is now active!' },
   failedTitle: { id: 'user.activated.failed.title', defaultMessage: 'Account Activation Failed' },
-  loginNow: { id: 'user.activated.login', defaultMessage: 'Login to Media Cloud' },
+  loginNow: { id: 'user.activated.login', defaultMessage: 'Login to CivicSignal' },
   invalidToken: { id: 'user.activated.invalidToken', defaultMessage: 'That is an invalid token.' },
   invalidTokenActions: { id: 'user.activated.invalidTokenActions', defaultMessage: 'You\'ve probably already activated your account, in which case <a href="/#/login">you can login now</a>.  If that isn\'t working, click the button to resend the account activation link.' },
   didNotWork: { id: 'user.activated.invalidTokenActions', defaultMessage: 'Sorry, but that didn\'t work for some reason.  Try the link again, or click the button below to resend the account activation link.' },
@@ -55,10 +55,12 @@ const Activated = (props) => {
     );
   } else {
     content = (
+      <>
       <ErrorNotice>
         <FormattedMessage {...localMessages.didNotWork} />
-        {resendContent}
       </ErrorNotice>
+        <p>{resendContent}</p>
+      </>
     );
   }
   return (

--- a/src/components/user/Activated.js
+++ b/src/components/user/Activated.js
@@ -56,9 +56,9 @@ const Activated = (props) => {
   } else {
     content = (
       <>
-      <ErrorNotice>
-        <FormattedMessage {...localMessages.didNotWork} />
-      </ErrorNotice>
+        <ErrorNotice>
+          <FormattedMessage {...localMessages.didNotWork} />
+        </ErrorNotice>
         <p>{resendContent}</p>
       </>
     );


### PR DESCRIPTION
This PR fixes account activation pages by replacing `Media Cloud` with `CivicSignal` in various components such as account activation button and improves the overall layout of the page.

We also fix lint issues that were noted on `SelectedStoryContainer` and `StoryQuoteTable` components.

Fixes: #59 

Before:
<img width="1381" alt="Screenshot 2025-06-26 at 16 10 14" src="https://github.com/user-attachments/assets/399ee222-f218-4cdb-a86a-7fbd7c62c88d" />
<img width="1381" alt="Screenshot 2025-06-26 at 16 09 28" src="https://github.com/user-attachments/assets/a77bb2b9-fc03-4aa5-9ed8-d6be61a6e5b3" />



After:
<img width="1381" alt="Screenshot 2025-06-26 at 16 10 10" src="https://github.com/user-attachments/assets/6e36a328-cdea-4fc2-8446-7cd670115d46" />
<img width="1381" alt="Screenshot 2025-06-26 at 15 34 18" src="https://github.com/user-attachments/assets/2056663d-d4c1-4f36-a42d-a03c0a10828c" />
